### PR TITLE
Drop support for `grok < 5`.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,9 @@ Changelog of megrok.strictrequire
 
 - Drop support for Python 2.7, 3.4, 3.5, 3.6.
 
+- Drop support for ``grok < 5``, thus dropping support for JSON, REST and
+  XMLRPC.
+
 - Add support for Python 3.7, 3.8, 3.9, 3.10, 3.11.
 
 

--- a/setup.py
+++ b/setup.py
@@ -61,7 +61,7 @@ setup(
     install_requires=[
         'setuptools',
         'martian',
-        'grok >= 3.0',
+        'grok >= 5.0a1',
     ],
     extras_require={
         'test': tests_require

--- a/src/megrok/strictrequire/meta.py
+++ b/src/megrok/strictrequire/meta.py
@@ -58,24 +58,3 @@ class CheckRequireGrokkerAddForm(CheckRequireGrokker):
 class CheckRequireGrokkerEditForm(CheckRequireGrokker):
     """Ensure every grok.EditForm has a grok.require directive"""
     martian.component(grok.EditForm)
-
-
-class CheckRequireRESTGrokker(martian.MethodGrokker):
-    """Ensure every grok.REST has a grok.require directive"""
-    martian.component(grok.REST)
-    martian.directive(grok.require, default=_require_marker)
-
-    def execute(self, factory, method, config, require, **kw):
-        if require is _require_marker:
-            raise SecurityError(
-                'megrok.strictrequire requires %r to use the grok.require '
-                'directive on the method: %s!' % (factory, method), factory)
-        return True
-
-
-class CheckRequireXMLPRCGrokker(CheckRequireRESTGrokker):
-    martian.component(grok.XMLRPC)
-
-
-class CheckRequireJSONGrokker(CheckRequireRESTGrokker):
-    martian.component(grok.JSON)

--- a/src/megrok/strictrequire/tests/checkrequire.rst
+++ b/src/megrok/strictrequire/tests/checkrequire.rst
@@ -30,8 +30,7 @@ Ditto for grok.Form, grok.AddForm. grok.EditForm, grok.XMLRPC, grok.JSON,
 grok.REST components::
 
     >>> from megrok.strictrequire.tests.fixtures import (
-    ...     NoRequireForm, NoRequireAddForm, NoRequireEditForm,
-    ...     NoRequireXMLRPC, NoRequireREST, NoRequireJSON)
+    ...     NoRequireForm, NoRequireAddForm, NoRequireEditForm)
     >>> grok_component('NoRequireForm', NoRequireForm)
     Traceback (most recent call last):
     ...
@@ -47,28 +46,12 @@ grok.REST components::
     ...
     megrok.strictrequire.meta.SecurityError: megrok.strictrequire requires <class 'megrok.strictrequire.tests.fixtures.NoRequireEditForm'> to use the grok.require directive!
 
-    >>> grok_component('NoRequireXMLRPC', NoRequireXMLRPC)
-    Traceback (most recent call last):
-    ...
-    megrok.strictrequire.meta.SecurityError: megrok.strictrequire requires <class 'megrok.strictrequire.tests.fixtures.NoRequireXMLRPC'> to use the grok.require directive on the method:...NoRequireXMLRPC.foobar...
-
-    >>> grok_component('NoRequireREST', NoRequireREST)
-    Traceback (most recent call last):
-    ...
-    megrok.strictrequire.meta.SecurityError: megrok.strictrequire requires <class 'megrok.strictrequire.tests.fixtures.NoRequireREST'> to use the grok.require directive on the method:...NoRequireREST.foobar...
-
-    >>> grok_component('NoRequireJSON', NoRequireJSON)
-    Traceback (most recent call last):
-    ...
-    megrok.strictrequire.meta.SecurityError: megrok.strictrequire requires <class 'megrok.strictrequire.tests.fixtures.NoRequireJSON'> to use the grok.require directive on the method:...NoRequireJSON.foobar...
-
 Of course, when the grok.require directive *is* used, there should not be any
 exception raised::
 
     >>> from megrok.strictrequire.tests.fixtures import (
     ...     RequireView, RequirePage, RequireForm, RequireAddForm,
-    ...     RequireEditForm, RequireXMLRPC, RequireREST, RequireJSON,
-    ...     RequireOnMethodXMLRPC, RequireOnMethodREST, RequireOnMethodJSON)
+    ...     RequireEditForm)
     >>> grok_component('RequireView', RequireView)
     True
     >>> grok_component('RequirePage', RequirePage)
@@ -78,18 +61,6 @@ exception raised::
     >>> grok_component('RequireAddForm', RequireAddForm)
     True
     >>> grok_component('RequireEditForm', RequireEditForm)
-    True
-    >>> grok_component('RequireXMLRPC', RequireXMLRPC)
-    True
-    >>> grok_component('RequireREST', RequireREST)
-    True
-    >>> grok_component('RequireJSON', RequireJSON)
-    True
-    >>> grok_component('RequireOnMethodXMLRPC', RequireOnMethodXMLRPC)
-    True
-    >>> grok_component('RequireOnMethodREST', RequireOnMethodREST)
-    True
-    >>> grok_component('RequireOnMethodJSON', RequireOnMethodJSON)
     True
 
 """

--- a/src/megrok/strictrequire/tests/fixtures.py
+++ b/src/megrok/strictrequire/tests/fixtures.py
@@ -56,27 +56,6 @@ class NoRequireEditForm(grok.EditForm):
     grok.context(zope.interface.Interface)
 
 
-class NoRequireXMLRPC(grok.XMLRPC):
-    grok.context(zope.interface.Interface)
-
-    def foobar(self):
-        pass
-
-
-class NoRequireREST(grok.REST):
-    grok.context(zope.interface.Interface)
-
-    def foobar(self):
-        pass
-
-
-class NoRequireJSON(grok.JSON):
-    grok.context(zope.interface.Interface)
-
-    def foobar(self):
-        pass
-
-
 class RequireView(grok.View):
     grok.context(zope.interface.Interface)
     grok.require('zope.Public')
@@ -106,51 +85,3 @@ class RequireAddForm(grok.AddForm):
 class RequireEditForm(grok.EditForm):
     grok.context(zope.interface.Interface)
     grok.require('zope.Public')
-
-
-class RequireXMLRPC(grok.XMLRPC):
-    grok.context(zope.interface.Interface)
-    grok.require('zope.Public')
-
-    def foobar(self):
-        pass
-
-
-class RequireREST(grok.REST):
-    grok.context(zope.interface.Interface)
-    grok.require('zope.Public')
-
-    def foobar(self):
-        pass
-
-
-class RequireJSON(grok.JSON):
-    grok.context(zope.interface.Interface)
-    grok.require('zope.Public')
-
-    def foobar(self):
-        pass
-
-
-class RequireOnMethodXMLRPC(grok.XMLRPC):
-    grok.context(zope.interface.Interface)
-
-    @grok.require('zope.Public')
-    def foobar(self):
-        pass
-
-
-class RequireOnMethodREST(grok.REST):
-    grok.context(zope.interface.Interface)
-
-    @grok.require('zope.Public')
-    def foobar(self):
-        pass
-
-
-class RequireOnMethodJSON(grok.JSON):
-    grok.context(zope.interface.Interface)
-
-    @grok.require('zope.Public')
-    def foobar(self):
-        pass


### PR DESCRIPTION
Thus dropping support for JSON, REST and XMLRPC.